### PR TITLE
Setting model constructor values to null

### DIFF
--- a/src/Model/Clip.php
+++ b/src/Model/Clip.php
@@ -333,14 +333,14 @@ class Clip implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->container['asset'] = $data['asset'] ?? null;
         $this->container['start'] = $data['start'] ?? null;
         $this->container['length'] = $data['length'] ?? null;
-        $this->container['fit'] = $data['fit'] ?? 'crop';
+        $this->container['fit'] = $data['fit'] ?? null;
         $this->container['scale'] = $data['scale'] ?? null;
-        $this->container['position'] = $data['position'] ?? 'center';
+        $this->container['position'] = $data['position'] ?? null;
         $this->container['offset'] = $data['offset'] ?? null;
         $this->container['transition'] = $data['transition'] ?? null;
         $this->container['effect'] = $data['effect'] ?? null;
         $this->container['filter'] = $data['filter'] ?? null;
-        $this->container['opacity'] = $data['opacity'] ?? 1;
+        $this->container['opacity'] = $data['opacity'] ?? null;
         $this->container['transform'] = $data['transform'] ?? null;
     }
 

--- a/src/Model/HtmlAsset.php
+++ b/src/Model/HtmlAsset.php
@@ -243,8 +243,8 @@ class HtmlAsset implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->container['css'] = $data['css'] ?? null;
         $this->container['width'] = $data['width'] ?? null;
         $this->container['height'] = $data['height'] ?? null;
-        $this->container['background'] = $data['background'] ?? 'transparent';
-        $this->container['position'] = $data['position'] ?? 'center';
+        $this->container['background'] = $data['background'] ?? null;
+        $this->container['position'] = $data['position'] ?? null;
     }
 
     /**

--- a/src/Model/Timeline.php
+++ b/src/Model/Timeline.php
@@ -200,7 +200,7 @@ class Timeline implements ModelInterface, ArrayAccess, \JsonSerializable
     public function __construct(array $data = null)
     {
         $this->container['soundtrack'] = $data['soundtrack'] ?? null;
-        $this->container['background'] = $data['background'] ?? '#000000';
+        $this->container['background'] = $data['background'] ?? null;
         $this->container['fonts'] = $data['fonts'] ?? null;
         $this->container['tracks'] = $data['tracks'] ?? null;
         $this->container['cache'] = $data['cache'] ?? true;

--- a/src/Model/TitleAsset.php
+++ b/src/Model/TitleAsset.php
@@ -302,10 +302,10 @@ class TitleAsset implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->container['type'] = $data['type'] ?? 'title';
         $this->container['text'] = $data['text'] ?? null;
         $this->container['style'] = $data['style'] ?? null;
-        $this->container['color'] = $data['color'] ?? '#ffffff';
-        $this->container['size'] = $data['size'] ?? 'medium';
+        $this->container['color'] = $data['color'] ?? null;
+        $this->container['size'] = $data['size'] ?? null;
         $this->container['background'] = $data['background'] ?? null;
-        $this->container['position'] = $data['position'] ?? 'center';
+        $this->container['position'] = $data['position'] ?? null;
         $this->container['offset'] = $data['offset'] ?? null;
     }
 

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -402,9 +402,17 @@ class ObjectSerializer
                 }
 
                 if (isset($data->{$instance::attributeMap()[$property]})) {
-                    $propertyValue = $data->{$instance::attributeMap()[$property]};
-                    $instance->$propertySetter(self::deserialize($propertyValue, $type, null));
-                }
+					$propertyValue = $data->{$instance::attributeMap()[$property]};
+
+					if ($type == '\Shotstack\Client\Model\Asset' && isset($propertyValue->type)) {
+						$_class = sprintf('\Shotstack\Client\Model\%sAsset', ucfirst($propertyValue->type));
+						if (class_exists($_class)) {
+							$type = $_class;
+						}
+					}
+
+					$instance->$propertySetter(self::deserialize($propertyValue, $type, null));
+				}
             }
             return $instance;
         }


### PR DESCRIPTION
While parsing a template, some of the model's default values break the output. Any invalid properties should be dealt with subsequently