### PR TITLE
feat: add automated SDK regeneration workflow

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,0 +1,20 @@
+name: Regenerate SDK
+
+on:
+  repository_dispatch:
+    types: [oas-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'OAS version to regenerate from (e.g. 1.9.10)'
+        required: true
+        type: string
+
+jobs:
+  regenerate:
+    uses: shotstack/oas-api-definition/.github/workflows/regenerate-sdk.yml@main
+    with:
+      oas-version: ${{ github.event.client_payload.version || inputs.version }}
+      language: php
+    secrets:
+      PR_TOKEN: ${{ secrets.SDK_PR_TOKEN }}

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -1,0 +1,7 @@
+# Preserve custom files during SDK regeneration
+README.md
+.github/**
+.openapi-generator-ignore
+.gitignore
+.oas-version
+scripts/**


### PR DESCRIPTION
Add receiver workflow that triggers on repository_dispatch from OAS repo and calls the shared regenerate-sdk reusable workflow. Also adds .openapi-generator-ignore to preserve README and custom files.